### PR TITLE
Add QueueStatus.ABANDONED

### DIFF
--- a/.github/workflows/Linting.yml
+++ b/.github/workflows/Linting.yml
@@ -1,6 +1,6 @@
 name: Linting
 
-on: [push, pull]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/Linting.yml
+++ b/.github/workflows/Linting.yml
@@ -1,6 +1,6 @@
 name: Linting
 
-on: [push]
+on: [push, pull]
 
 jobs:
   build:

--- a/OpenOrchestrator/database/db_util.py
+++ b/OpenOrchestrator/database/db_util.py
@@ -838,7 +838,7 @@ def get_queue_count() -> dict[str, dict[QueueStatus, int]]:
 def set_queue_element_status(element_id: str, status: QueueStatus, message: str = None) -> None:
     """Set the status of a queue element.
     If the new status is 'in progress' the start date is noted.
-    If the new status is 'Done' or 'Failed' the end date is noted.
+    If the new status is 'Done', 'Failed' or 'Abandoned' the end date is noted.
 
     Args:
         element_id: The id of the queue element to change status on.
@@ -855,7 +855,7 @@ def set_queue_element_status(element_id: str, status: QueueStatus, message: str 
         match status:
             case QueueStatus.IN_PROGRESS:
                 q_element.start_date = datetime.now()
-            case QueueStatus.DONE | QueueStatus.FAILED:
+            case QueueStatus.DONE | QueueStatus.FAILED | QueueStatus.ABANDONED:
                 q_element.end_date = datetime.now()
 
         session.commit()

--- a/OpenOrchestrator/database/queues.py
+++ b/OpenOrchestrator/database/queues.py
@@ -20,6 +20,7 @@ class QueueStatus(enum.Enum):
     IN_PROGRESS = 'In Progress'
     DONE = 'Done'
     FAILED = 'Failed'
+    ABANDONED = 'Abandoned'
 
 
 class Base(DeclarativeBase):

--- a/OpenOrchestrator/orchestrator/tabs/queue_tab.py
+++ b/OpenOrchestrator/orchestrator/tabs/queue_tab.py
@@ -12,7 +12,8 @@ QUEUE_COLUMNS = (
     {'name': "New", 'label': "New", 'field': "New", 'align': 'left', 'sortable': True},
     {'name': "In Progress", 'label': "In Progress", 'field': "In Progress", 'align': 'left', 'sortable': True},
     {'name': "Done", 'label': "Done", 'field': "Done", 'align': 'left', 'sortable': True},
-    {'name': "Failed", 'label': "Failed", 'field': "Failed", 'align': 'left', 'sortable': True}
+    {'name': "Failed", 'label': "Failed", 'field': "Failed", 'align': 'left', 'sortable': True},
+    {'name': "Abandoned", 'label': "Abandoned", 'field': "Abandoned", 'align': 'left', 'sortable': True}
 )
 
 ELEMENT_COLUMNS = (
@@ -48,7 +49,8 @@ class QueueTab():
                 "New": count.get(QueueStatus.NEW, 0),
                 "In Progress": count.get(QueueStatus.IN_PROGRESS, 0),
                 "Done": count.get(QueueStatus.DONE, 0),
-                "Failed": count.get(QueueStatus.FAILED, 0)
+                "Failed": count.get(QueueStatus.FAILED, 0),
+                "Abandoned": count.get(QueueStatus.ABANDONED, 0),
             }
             rows.append(row)
 

--- a/OpenOrchestrator/orchestrator_connection/connection.py
+++ b/OpenOrchestrator/orchestrator_connection/connection.py
@@ -169,7 +169,7 @@ class OrchestratorConnection:
     def set_queue_element_status(self, element_id: str, status: QueueStatus, message: str = None) -> None:
         """Set the status of a queue element.
         If the new status is 'in progress' the start date is noted.
-        If the new status is 'Done' or 'Failed' the end date is noted.
+        If the new status is 'Done', 'Failed' or 'Abandoned' the end date is noted.
 
         Args:
             element_id: The id of the queue element to change status on.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- 'Abandoned' status to queue elements.
+
 ## [1.2.0] - 2024-02-27
 
 ### Changed


### PR DESCRIPTION
Implementation of https://github.com/itk-dev-rpa/OpenOrchestrator/issues/77

In addition to adding a new Abandoned state for queue items, I also let the function "set_queue_element_status" update the end_date of a queue item if its state is Abandoned.