### PR TITLE
Added color to 'Paused'

### DIFF
--- a/OpenOrchestrator/orchestrator/tabs/trigger_tab.py
+++ b/OpenOrchestrator/orchestrator/tabs/trigger_tab.py
@@ -58,7 +58,7 @@ class TriggerTab():
             "body-cell-Status",
             '''
             <q-td key="Status" :props="props">
-                <q-badge v-if="{Running: 'green', Pausing: 'orange', Failed: 'red'}[props.value]" :color="{Running: 'green', Pausing: 'orange', Failed: 'red'}[props.value]">
+                <q-badge v-if="{Running: 'green', Pausing: 'orange', Paused: 'orange', Failed: 'red'}[props.value]" :color="{Running: 'green', Pausing: 'orange', Paused: 'orange', Failed: 'red'}[props.value]">
                     {{props.value}}
                 </q-badge>
                 <p v-else>

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Trigger status 'Paused' is now colored orange in the trigger tab.
+
 ## [1.3.0] - 2024-06-19
 
 ### Added


### PR DESCRIPTION
### Changed

- Trigger status 'Paused' is now colored orange in the trigger tab.