### PR TITLE
Remove limit for string columns when initializing db.

### DIFF
--- a/OpenOrchestrator/database/constants.py
+++ b/OpenOrchestrator/database/constants.py
@@ -19,7 +19,7 @@ class Constant(Base):
     """A class representing a constant object in the ORM."""
     __tablename__ = "Constants"
 
-    name: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), primary_key=True)
     value: Mapped[str] = mapped_column(String)
     changed_at: Mapped[datetime] = mapped_column(onupdate=datetime.now, default=datetime.now)
 
@@ -36,7 +36,7 @@ class Credential(Base):
     """A class representing a credential object in the ORM."""
     __tablename__ = "Credentials"
 
-    name: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), primary_key=True)
     username: Mapped[str] = mapped_column(String)
     password: Mapped[str] = mapped_column(String)
     changed_at: Mapped[datetime] = mapped_column(onupdate=datetime.now, default=datetime.now)

--- a/OpenOrchestrator/database/constants.py
+++ b/OpenOrchestrator/database/constants.py
@@ -19,8 +19,8 @@ class Constant(Base):
     """A class representing a constant object in the ORM."""
     __tablename__ = "Constants"
 
-    name: Mapped[str] = mapped_column(String(100), primary_key=True)
-    value: Mapped[str] = mapped_column(String(1000))
+    name: Mapped[str] = mapped_column(String, primary_key=True)
+    value: Mapped[str] = mapped_column(String)
     changed_at: Mapped[datetime] = mapped_column(onupdate=datetime.now, default=datetime.now)
 
     def to_row_dict(self) -> dict[str, str]:
@@ -36,9 +36,9 @@ class Credential(Base):
     """A class representing a credential object in the ORM."""
     __tablename__ = "Credentials"
 
-    name: Mapped[str] = mapped_column(String(100), primary_key=True)
-    username: Mapped[str] = mapped_column(String(250))
-    password: Mapped[str] = mapped_column(String(1000))
+    name: Mapped[str] = mapped_column(String, primary_key=True)
+    username: Mapped[str] = mapped_column(String)
+    password: Mapped[str] = mapped_column(String)
     changed_at: Mapped[datetime] = mapped_column(onupdate=datetime.now, default=datetime.now)
 
     def to_row_dict(self) -> dict[str, str]:

--- a/OpenOrchestrator/database/queues.py
+++ b/OpenOrchestrator/database/queues.py
@@ -34,12 +34,12 @@ class QueueElement(Base):
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     queue_name: Mapped[str] = mapped_column(String(100), index=True)
     status: Mapped[QueueStatus] = mapped_column(default=QueueStatus.NEW)
-    data: Mapped[Optional[str]] = mapped_column(String(2000))
-    reference: Mapped[Optional[str]] = mapped_column(String(100))
+    data: Mapped[Optional[str]] = mapped_column(String)
+    reference: Mapped[Optional[str]] = mapped_column(String)
     created_date: Mapped[datetime] = mapped_column(default=datetime.now, index=True)
     start_date: Mapped[Optional[datetime]]
     end_date: Mapped[Optional[datetime]]
-    message: Mapped[Optional[str]] = mapped_column(String(1000))
+    message: Mapped[Optional[str]] = mapped_column(String)
     created_by: Mapped[Optional[str]] = mapped_column(String(100))
 
     def to_row_dict(self) -> dict:


### PR DESCRIPTION
Remove unnecessary string length limit when using sqlalchemy from constant/credentials so it uses the sql servers default max as sometimes there might be values longer than 1000 characters, e.g. bearer token can sometimes be 1000+ characters (KMD 😅). If it's to fix an ui bug or similar, i would suggest making it 1500+ characters. 